### PR TITLE
Add features for spawning workcarts and running commands

### DIFF
--- a/AutomatedWorkcarts.cs
+++ b/AutomatedWorkcarts.cs
@@ -17,7 +17,7 @@ using static TrainTrackSpline;
 
 namespace Oxide.Plugins
 {
-    [Info("Automated Workcarts", "WhiteThunder", "0.25.1")]
+    [Info("Automated Workcarts", "WhiteThunder", "0.25.2")]
     [Description("Automates workcarts with NPC conductors.")]
     internal class AutomatedWorkcarts : CovalencePlugin
     {
@@ -1077,7 +1077,7 @@ namespace Oxide.Plugins
 
         private static TrainEngine GetFasterWorkcart(TrainEngine workcart, TrainEngine otherWorkcart)
         {
-            return Math.Abs(workcart.TrackSpeed) >= Math.Abs(otherWorkcart.TrackSpeed)
+            return Math.Abs(workcart.GetTrackSpeed()) >= Math.Abs(otherWorkcart.GetTrackSpeed())
                 ? workcart
                 : otherWorkcart;
         }
@@ -2449,7 +2449,7 @@ namespace Oxide.Plugins
             public void UpdateWorkcartData()
             {
                 _workcartData.Throttle = DepartureThrottle;
-                _workcartData.TrackSelection = Workcart.curTrackSelection;
+                _workcartData.TrackSelection = Workcart.localTrackSelection;
             }
 
             public void HandleConductorTrigger(TriggerData triggerData)
@@ -2489,7 +2489,7 @@ namespace Oxide.Plugins
                 var currentDepartureThrottle = DepartureThrottle;
                 var newDepartureThrottle = DetermineNextThrottle(currentDepartureThrottle, departureSpeedInstruction, directionInstruction);
 
-                Workcart.SetTrackSelection(DetermineNextTrackSelection(Workcart.curTrackSelection, triggerData.GetTrackSelectionInstruction()));
+                Workcart.SetTrackSelection(DetermineNextTrackSelection(Workcart.localTrackSelection, triggerData.GetTrackSelectionInstruction()));
 
                 if (triggerData.Brake)
                 {

--- a/AutomatedWorkcarts.cs
+++ b/AutomatedWorkcarts.cs
@@ -18,7 +18,7 @@ using static TrainTrackSpline;
 
 namespace Oxide.Plugins
 {
-    [Info("Automated Workcarts", "WhiteThunder", "0.25.2")]
+    [Info("Automated Workcarts", "WhiteThunder", "0.26.0")]
     [Description("Automates workcarts with NPC conductors.")]
     internal class AutomatedWorkcarts : CovalencePlugin
     {

--- a/AutomatedWorkcarts.cs
+++ b/AutomatedWorkcarts.cs
@@ -175,7 +175,7 @@ namespace Oxide.Plugins
                 {
                     forwardController.DepartEarlyIfStoppedOrStopping();
                 }
-                else if (Math.Abs(EngineThrottleToNumber(forwardWorkcart.CurThrottleSetting)) < Math.Abs(EngineThrottleToNumber(backwardWorkcart.CurThrottleSetting)))
+                else if (_pluginConfig.BulldozeOffendingWorkcarts && Math.Abs(EngineThrottleToNumber(forwardWorkcart.CurThrottleSetting)) < Math.Abs(EngineThrottleToNumber(backwardWorkcart.CurThrottleSetting)))
                 {
                     // Destroy the forward workcart if it's not automated and going too slow.
                     LogWarning($"Destroying non-automated workcart due to insufficient speed.");

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ To see the triggers visually, grant the `automatedworkcarts.managetriggers` perm
 - `aw.removetrigger <id>` -- Removes the specified trigger.
 - `aw.enabletrigger <id>` -- Enables the specified trigger. This is identical to `aw.updatetrigger <id> enabled`.
 - `aw.disabletrigger <id>` -- Disables the specified trigger. This is identical to `aw.updatetrigger <id> disabled`. Disabled triggers are ignored by workcarts and are colored gray.
+- `aw.addtriggercommand <id> <command>` -- Adds the specified command to the trigger, which will be executed whenever a workcart passes through the trigger. You can use the magic variable `$id` in the command which will be replaced by the workcart's Net ID.
+- `aw.removetriggercommand <id> <number>` -- Removes the specified command from the trigger. The command number will be 1, 2, 3, etc. and will be visible on the trigger info when using `aw.showtriggers`.
 
 Tip: For the commands that update, move or remove triggers, you can skip the `<id>` argument if you are aiming at a nearby trigger.
 
@@ -146,6 +148,8 @@ The following command aliases are available:
 - `aw.removetrigger` -> `awt.remove`
 - `aw.enabletrigger` -> `awt.enable`
 - `aw.disabletrigger` -> `awt.disable`
+- `aw.addtriggercommand` -> `awt.addcommand`
+- `aw.removetriggercommand` -> `awt.removecommand`
 
 ### Command examples
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,40 @@
 
 - Automates workcarts with NPC conductors
 - Uses configurable triggers to instruct conductors how to navigate
+- Optionally spawns workcarts at trigger locations
 - Provides default triggers for underground tunnels
 - Optional map markers for automated workcarts
+
+Note: This plugin is not designed for the procedurally generated aboveground rail network, nor is it designed for the new train carriages. Further development will go into this plugin when Facepunch finalizes the aboveground rail network by doubling the tracks and adding designated stopping locations.
 
 ## How it works
 
 A workcart can be automated one of two ways:
+
 - By running the `aw.toggle` command while looking at the workcart.
 - By placing a trigger on the workcart spawn position, so that it will receive a conductor when it spawns.
 
 Automating a workcart dismounts the current driver if present, and adds a conductor NPC.
+
 - The conductor and workcart are invincible, and the workcart does not require fuel.
 - If the workcart was automated using the `aw.toggle` command, the conductor will start driving based on the `DefaultSpeed` and `DefaultTrackSelection` in the plugin configuration.
 - If the workcart was automated using a trigger, it will use the trigger options, falling back to the plugin configuration for anything not specified by the trigger.
 
-The main purpose of triggers, aside from determining which workcarts will be automated, is to instruct conductors how to navigate the tracks. Each trigger has several properties, including direction (e., `Fwd`, `Rev`, `Invert`), speed (e.g, `Hi`, `Med`, `Lo`, `Zero`), track selection (e.g., `Default`, `Left`, `Right`), stop duration (in seconds), and departure speed/direction. When a workcart passes through a trigger while a conductor is present, the workcart's instructions will change based on the trigger properties. For example, if a workcart is currently following the instructions `Fwd` + `Hi` + `Left`, and then passes through a trigger that specifies only track selection `Right`, the workcart instructions will change to `Fwd` + `Hi` + `Right`, causing the workcart to turn right at every intersection it comes to, until it passes through a trigger that instructs otherwise.
+### How triggers work
+
+Triggers can be used to achieve multiple goals:
+
+- To spawn workcarts
+- To turn workcarts into automated workcarts
+- To instruct automated workcarts how to navigate the tracks
+
+Each trigger can have multiple properties, including direction (e., `Fwd`, `Rev`, `Invert`), speed (e.g, `Hi`, `Med`, `Lo`, `Zero`), track selection (e.g., `Default`, `Left`, `Right`), stop duration (in seconds), and departure speed/direction. When an automated workcart passes through a trigger, its instructions will change based on the trigger properties. For example, if a workcart is currently following the instructions `Fwd` + `Hi` + `Left`, and then passes through a trigger that specifies only track selection `Right`, the workcart instructions will change to `Fwd` + `Hi` + `Right`, causing the workcart to turn right at every intersection it comes to, until it passes through a trigger that instructs otherwise.
 
 ### Trigger types
 
 #### Map specific triggers
 
-- Can be placed anywhere on train tracks, even in underground tunnels.
+- Can be placed anywhere on train tracks, above or below ground.
 - Only apply to the map they were placed on.
 - Enabled via the `EnableMapTriggers` configuration option.
 - Added with the `aw.addtrigger` or `awt.add` command.
@@ -31,7 +44,7 @@ The main purpose of triggers, aside from determining which workcarts will be aut
 
 #### Tunnel triggers
 
-- Can be placed only in the vanilla train tunnels (usually underground).
+- Can be placed only in the vanilla train tunnels.
 - Automatically replicate at all tunnels of the same type.
 - Enabled via the `EnableTunnelTriggers` -> `*` options.
 - Added with the `aw.addtunneltrigger` or `awt.addt` command.
@@ -76,6 +89,8 @@ To see the triggers visually, grant the `automatedworkcarts.managetriggers` perm
 
 ### How to: Automate aboveground workcarts
 
+Note: This section was originally written assuming you are using a custom map to add aboveground rails, not the new procedurally generated aboveground rail network.
+
 1. If you are a map developer, please see the "Tips for map developers" section below. Designing the tracks sensibly will simplify setting up automated routes.
 2. Carefully examine the tracks on your map to determine the route(s) you would like workcarts to use.
 3. Make sure `EnableMapTriggers` is set to `true` in the plugin configuration. This option is enabled by default if installing the plugin from scratch.
@@ -111,9 +126,10 @@ To see the triggers visually, grant the `automatedworkcarts.managetriggers` perm
   - Direction options: `Fwd` | `Rev` | `Invert`.
   - Track selection options: `Default` | `Left` | `Right` | `Swap`.
   - Other options:
+    - `Spawn` -- Spawns a workcart at this trigger. Each trigger can spawn at most one workcart. The workcart will despawn when the trigger is removed, when the trigger is disabled, when this property is removed from the trigger, or when the plugin reloads. If the workcart is destroyed, the workcart will attempt to respawn within 30 seconds.
     - `Conductor` -- Adds a conductor to the workcart if not already present. Recommended to place on some or all workcart spawn locations, depending on how many workcarts you want to automate.
       - Note: Owned workcarts cannot receive conductors. Vanilla workcarts don't have owners, but most plugins that spawn vehicles for players will assign ownership.
-    - `Brake` -- Instructs the workcart to brake until it reaches the designated speed. For example, if the workcart is going `Fwd_Hi` and enters a `Brake Med` trigger, it will temporarily go `Rev_Lo` until it slows down enough, then it will go `Fwd Med`.
+    - `Brake` -- Instructs the workcart to brake until it reaches the designated speed. For example, if the workcart is going `Fwd_Hi` and enters a `Brake Med` trigger, it will temporarily go `Rev_Lo` until it slows down enough, then it will go `Fwd_Med`.
     - `Destroy` -- Destroys the workcart. This is intended for lazy track designs. You should not need this if you design your routes thoughtfully.
     - `@<route_name>` -- Instructs the workcart to ignore this trigger if it's not assigned this route (replace `<route_name>` with the name you want).
       - If the trigger has the `Conductor` property and the workcart does not already have a conductor, it will be assigned this route.
@@ -128,6 +144,7 @@ To see the triggers visually, grant the `automatedworkcarts.managetriggers` perm
   - Options are the same as for `aw.addtrigger`.
   - This is useful for removing properties from a trigger (without having to remove and add it back) since `aw.updatetrigger` does not remove properties.
 - `aw.movetrigger <id>` -- Moves the specified trigger to the track position where the player is aiming.
+- `aw.rotatetrigger <id>` -- Rotates the specified trigger to where the player is facing. This is only useful for `Spawn` triggers since it determines which way the workcart will be facing when spawned.
 - `aw.removetrigger <id>` -- Removes the specified trigger.
 - `aw.enabletrigger <id>` -- Enables the specified trigger. This is identical to `aw.updatetrigger <id> enabled`.
 - `aw.disabletrigger <id>` -- Disables the specified trigger. This is identical to `aw.updatetrigger <id> disabled`. Disabled triggers are ignored by workcarts and are colored gray.
@@ -145,6 +162,7 @@ The following command aliases are available:
 - `aw.updatetrigger` -> `awt.update`
 - `aw.replacetrigger` -> `awt.replace`
 - `aw.movetrigger` -> `awt.move`
+- `aw.rotatetrigger` -> `awt.rotate`
 - `aw.removetrigger` -> `awt.remove`
 - `aw.enabletrigger` -> `awt.enable`
 - `aw.disabletrigger` -> `awt.disable`
@@ -256,10 +274,6 @@ Default configuration:
 - `TriggerDisplayDistance ` -- Determines how close you must be to a trigger to see it when viewing triggers.
 
 ## FAQ
-
-#### How can I get workcarts to spawn on custom maps?
-
-Use a free plugin called Workcart Spawner from another website (not allowed to post a link here).
 
 #### Will this plugin cause lag?
 

--- a/README.md
+++ b/README.md
@@ -294,58 +294,6 @@ The best practice is to have separate, independent tracks for player vs automate
 
 ## Localization
 
-```json
-{
-  "Error.NoPermission": "You don't have permission to do that.",
-  "Error.NoTriggers": "There are no workcart triggers on this map.",
-  "Error.TriggerNotFound": "Error: Trigger id #<color=#fd4>{0}{1}</color> not found.",
-  "Error.ErrorNoTrackFound": "Error: No track found nearby.",
-  "Error.NoWorkcartFound": "Error: No workcart found.",
-  "Error.AutomateBlocked": "Error: Another plugin blocked automating that workcart.",
-  "Error.UnsupportedTunnel": "Error: Not a supported train tunnel.",
-  "Error.TunnelTypeDisabled": "Error: Tunnel type <color=#fd4>{0}</color> is currently disabled.",
-  "Error.MapTriggersDisabled": "Error: Map triggers are disabled.",
-  "Error.MaxConductors": "Error: There are already <color=#fd4>{0}</color> out of <color=#fd4>{1}</color> conductors.",
-  "Error.WorkcartOwned": "Error: That workcart has an owner.",
-  "Error.NoAutomatedWorkcarts": "Error: There are no automated workcarts.",
-  "Toggle.Success.On": "That workcart is now automated.",
-  "Toggle.Success.On.WithRoute": "That workcart is now automated with route <color=#fd4>@{0}</color>.",
-  "Toggle.Success.Off": "That workcart is no longer automated.",
-  "ResetAll.Success": "All {0} conductors have been removed.",
-  "ShowTriggers.Success": "Showing all triggers for <color=#fd4>{0}</color>.",
-  "ShowTriggers.WithRoute.Success": "Showing all triggers for route <color=#fd4>@{0}</color> for <color=#fd4>{1}</color>",
-  "AddTrigger.Syntax": "Syntax: <color=#fd4>{0} <option1> <option2> ...</color>\n{1}",
-  "AddTrigger.Success": "Successfully added trigger #<color=#fd4>{0}{1}</color>.",
-  "UpdateTrigger.Syntax": "Syntax: <color=#fd4>{0} <id> <option1> <option2> ...</color>\n{1}",
-  "UpdateTrigger.Success": "Successfully updated trigger #<color=#fd4>{0}{1}</color>",
-  "MoveTrigger.Success": "Successfully moved trigger #<color=#fd4>{0}{1}</color>",
-  "Trigger.SimpleSyntax": "Syntax: <color=#fd4>{0} <id></color>",
-  "RemoveTrigger.Success": "Trigger #<color=#fd4>{0}{1}</color> successfully removed.",
-  "Info.ConductorCount.Limited": "Total conductors: <color=#fd4>{0}/{1}</color>.",
-  "Info.ConductorCount.Unlimited": "Total conductors: <color=#fd4>{0}</color>.",
-  "Help.SpeedOptions": "Speeds: {0}",
-  "Help.DirectionOptions": "Directions: {0}",
-  "Help.TrackSelectionOptions": "Track selection: {0}",
-  "Help.OtherOptions": "Other options: <color=#fd4>Conductor</color> | <color=#fd4>Brake</color> | <color=#fd4>Destroy</color> | <color=#fd4>@ROUTE_NAME</color> | <color=#fd4>Enabled</color> | <color=#fd4>Disabled</color>",
-  "Info.Trigger": "Workcart Trigger #{0}{1}",
-  "Info.Trigger.Prefix.Map": "M",
-  "Info.Trigger.Prefix.Tunnel": "T",
-  "Info.Trigger.Disabled": "DISABLED",
-  "Info.Trigger.Map": "Map-specific",
-  "Info.Trigger.Route": "Route: @{0}",
-  "Info.Trigger.Tunnel": "Tunnel type: {0} (x{1})",
-  "Info.Trigger.Conductor": "Adds Conductor",
-  "Info.Trigger.Destroy": "Destroys workcart",
-  "Info.Trigger.StopDuration": "Stop duration: {0}s",
-  "Info.Trigger.Speed": "Speed: {0}",
-  "Info.Trigger.BrakeToSpeed": "Brake to speed: {0}",
-  "Info.Trigger.DepartureSpeed": "Departure speed: {0}",
-  "Info.Trigger.Direction": "Direction: {0}",
-  "Info.Trigger.DepartureDirection": "Departure direction: {0}",
-  "Info.Trigger.TrackSelection": "Track selection: {0}"
-}
-```
-
 ## Developer API
 
 #### API_AutomateWorkcart


### PR DESCRIPTION
### New features

- Workcart triggers can now spawn workcarts when specifying the optional `Spawn` flag
- Each trigger can now optionally execute one or more server commands when an automated workcart touches it

### Bug fixes

- Fixed compile errors caused by Rust update
- Fixed an issue where automated workcarts would destroy non-automated workcarts even when `BulldozeOffendingWorkcarts` was set to `false`